### PR TITLE
Explicitly request PR write perm in Job

### DIFF
--- a/.github/workflows/branch_deployments.yml
+++ b/.github/workflows/branch_deployments.yml
@@ -19,6 +19,8 @@ jobs:
             build_folder: example_location
             registry_env: REGISTRY_URL
             location_file: cloud_workspace.yaml
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
Explicitly grants the `pull-requests: write` permission to the GitHub Actions Job which writes a PR status update. Ensures that the action works on locked-down repos which have the "restricted" default access pattern:

https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token

## Test Plan

Set this repo to the restricted access pattern, validated that the action succeeds still.